### PR TITLE
Build DLL using cross-compilation #2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ SUBDIRS= doc tests
 
 lib_LTLIBRARIES = libhyphen.la
 libhyphen_la_SOURCES = hnjalloc.c hyphen.c
-libhyphen_la_LDFLAGS = -version-info 3:0:3
+libhyphen_la_LDFLAGS = -version-info 3:0:3 -no-undefined
 include_HEADERS = hyphen.h
 noinst_HEADERS = hnjalloc.h
 

--- a/README
+++ b/README
@@ -71,6 +71,12 @@ to lowercase before hyphenation (under UTF-8 console environment):
 
 cat mywords.txt | awk '{print tolower($0)}' >mywordslow.txt
 
+BUILD DLL USING CROSS-COMPILATION
+
+./configure --host i586-mingw32 --prefix=/tmp/hyphen-dll
+make
+make install
+
 DEVELOPMENT
 
 See README.hyphen for hyphenation algorithm, README.nonstandard


### PR DESCRIPTION
This time, the changes for supporting `make check` aren't included because too specific.

See https://github.com/hunspell/hyphen/pull/5#issuecomment-234708829